### PR TITLE
chore: remove HashSet.insertMany

### DIFF
--- a/Aesop/Util/Basic.lean
+++ b/Aesop/Util/Basic.lean
@@ -536,13 +536,6 @@ end Lean.MessageData
 
 namespace Lean.HashSet
 
-def insertMany [ForIn Id ρ α] [BEq α] [Hashable α] (s : HashSet α) (as : ρ) :
-    HashSet α := Id.run do
-  let mut s := s
-  for a in as do
-    s := s.insert a
-  return s
-
 protected def ofArray [BEq α] [Hashable α] (as : Array α) : HashSet α :=
   HashSet.empty.insertMany as
 


### PR DESCRIPTION
This will need to wait for lean4 nightly-2022-11-29 to arrive.

We had ended up with `HashSet.insertMany` defined in both Aesop and mathlib4, making it impossible to import Aesop. 

It would probably be good preventative medicine to upstream much of the rest of this file to Std4, too.