### PR TITLE
Add unfold builder

### DIFF
--- a/Aesop/Builder.lean
+++ b/Aesop/Builder.lean
@@ -12,3 +12,4 @@ import Aesop.Builder.Default
 import Aesop.Builder.Forward
 import Aesop.Builder.NormSimp
 import Aesop.Builder.Tactic
+import Aesop.Builder.Unfold

--- a/Aesop/Builder/Basic.lean
+++ b/Aesop/Builder/Basic.lean
@@ -30,18 +30,11 @@ structure RegularRuleBuilderResult where
   mayUseBranchState : Bool
   deriving Inhabited
 
-structure GlobalSimpRuleBuilderResult where
-  builder : BuilderName
-  entries : Array SimpEntry
-
-structure LocalSimpRuleBuilderResult where
-  builder : BuilderName
-  fvarUserName : Name
-
 inductive RuleBuilderResult
   | regular (r : RegularRuleBuilderResult)
-  | globalSimp (r : GlobalSimpRuleBuilderResult)
-  | localSimp (r : LocalSimpRuleBuilderResult)
+  | globalSimp (entries : Array SimpEntry)
+  | localSimp (userName : Name)
+  | unfold (r : UnfoldRule)
   deriving Inhabited
 
 inductive RuleBuilderOutput

--- a/Aesop/Builder/Default.lean
+++ b/Aesop/Builder/Default.lean
@@ -41,7 +41,7 @@ def default : RuleBuilder := λ input =>
   | PhaseName.norm =>
     constructorsDef input <|>
     tacticDef input <|>
-    normSimpLemmas input <|>
+    simp input <|>
     applyDef input <|>
     err "a norm" input
   where

--- a/Aesop/Builder/Unfold.lean
+++ b/Aesop/Builder/Unfold.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Aesop.Builder.Basic
+
+open Lean
+open Lean.Meta
+
+namespace Aesop.RuleBuilder
+
+def unfold : RuleBuilder :=
+  ofGlobalRuleBuilder .unfold λ _ decl =>
+    return .unfold { decl, unfoldThm? := ← getUnfoldEqnFor? decl }
+
+end Aesop.RuleBuilder

--- a/Aesop/Profiling.lean
+++ b/Aesop/Profiling.lean
@@ -14,6 +14,7 @@ namespace Aesop
 
 inductive RuleProfileName
   | normSimp
+  | normUnfold
   | rule (name : RuleName)
   deriving Inhabited, BEq, Ord
 
@@ -23,11 +24,13 @@ instance : ToString RuleProfileName where
   toString
     | rule name => toString name
     | normSimp => "<norm simp>"
+    | normUnfold => "<norm unfold>"
 
 instance : Hashable RuleProfileName where
   hash
     | rule name => mixHash (hash name) 4589
     | normSimp => 788009
+    | normUnfold => 145389
 
 end RuleProfileName
 

--- a/Aesop/Rule.lean
+++ b/Aesop/Rule.lean
@@ -172,7 +172,6 @@ end NormSimpRule
 -- hypothesis to the simp set. This must be done for each goal individually
 -- since the `FVarId` of the hypothesis is not guaranteed to be stable.
 structure LocalNormSimpRule where
-  name : RuleName
   fvarUserName : Name
   deriving Inhabited
 
@@ -184,4 +183,26 @@ instance : BEq NormSimpRule where
 instance : Hashable NormSimpRule where
   hash r := hash r.name
 
+def name (r : LocalNormSimpRule) : RuleName :=
+  { name := r.fvarUserName, scope := .local, builder := .simp, phase := .norm }
+
 end LocalNormSimpRule
+
+
+structure UnfoldRule where
+  decl : Name
+  unfoldThm? : Option Name
+  deriving Inhabited
+
+namespace UnfoldRule
+
+instance : BEq UnfoldRule where
+  beq r s := r.decl == s.decl
+
+instance : Hashable UnfoldRule where
+  hash r := hash r.decl
+
+def name (r : UnfoldRule) : RuleName :=
+  { name := r.decl, builder := .unfold, phase := .norm, scope := .global }
+
+end Aesop.UnfoldRule

--- a/Aesop/Script.lean
+++ b/Aesop/Script.lean
@@ -398,6 +398,12 @@ def renameInaccessibleFVars (goal : MVarId) (renamedFVars : Array FVarId) :
         `(binderIdent| $userName:ident)
       `(tactic| rename_i $ids:binderIdent*)
 
+def unfoldManyStar (usedDecls : HashSet Name) : ScriptBuilder MetaM :=
+  if usedDecls.isEmpty then
+    .id
+  else
+    .ofTactic 1 `(tactic| aesop_unfold [$(usedDecls.toArray.map mkIdent):ident,*])
+
 end ScriptBuilder
 
 abbrev RuleTacScriptBuilder := ScriptBuilder MetaM
@@ -436,6 +442,12 @@ def _root_.Lean.MVarId.renameInaccessibleFVarsWithSyntax (goal : MVarId) :
     MetaM (MVarId × Array FVarId × ScriptBuilder MetaM) := do
   let (goal, renamedFVars) ← goal.renameInaccessibleFVars
   return (goal, renamedFVars, .renameInaccessibleFVars goal renamedFVars)
+
+def _root_.Lean.MVarId.unfoldManyStarWithSyntax (goal : MVarId)
+    (unfold? : Name → Option (Option Name)) :
+    MetaM (UnfoldResult × ScriptBuilder MetaM) := do
+  let result ← goal.unfoldManyStar unfold?
+  return (result, .unfoldManyStar result.usedDecls)
 
 
 -- TODO rename to `TacticInvocation`

--- a/Aesop/Search/Expansion/Simp/Basic.lean
+++ b/Aesop/Search/Expansion/Simp/Basic.lean
@@ -6,6 +6,7 @@ Authors: Jannis Limperg
 
 import Aesop.Options
 import Aesop.Script
+import Aesop.RuleSet
 
 open Lean Lean.Meta
 open Simp (UsedSimps)
@@ -92,5 +93,13 @@ def mkNormSimpOnlySyntax (inGoal : MVarId) (normSimpUseHyps : Bool)
   let stx ← inGoal.withContext do
     mkSimpOnly originalStx usedTheorems (includeFVars := includeFVars)
   return ⟨stx⟩
+
+def mkNormSimpContext (rs : RuleSet) (simpConfig : Aesop.SimpConfig) :
+    MetaM Simp.Context :=
+  return {
+    ← Simp.Context.mkDefault with
+    simpTheorems := #[rs.normSimpLemmas]
+    config := simpConfig.toConfig
+  }
 
 end Aesop

--- a/Aesop/Search/Expansion/Simp/SimpGoal.lean
+++ b/Aesop/Search/Expansion/Simp/SimpGoal.lean
@@ -71,4 +71,20 @@ def simpGoal (mvarId : MVarId) (ctx : Simp.Context)
       let mvarIdNew ← mvarIdNew.tryClearMany toClear
       return .simplified mvarIdNew usedSimps
 
+def simpGoalWithAllHypotheses (mvarId : MVarId) (ctx : Simp.Context)
+    (discharge? : Option Simp.Discharge := none)
+    (simplifyTarget : Bool := true)
+    (usedSimps : UsedSimps := {})
+    (disabledTheorems : HashMap FVarId Origin := {}) :
+    MetaM SimpResult :=
+  mvarId.withContext do
+    let lctx ← getLCtx
+    let mut fvarIdsToSimp := Array.mkEmpty lctx.decls.size
+    for ldecl in lctx do
+      if ldecl.isImplementationDetail then
+        continue
+      fvarIdsToSimp := fvarIdsToSimp.push ldecl.fvarId
+    Aesop.simpGoal mvarId ctx discharge? simplifyTarget fvarIdsToSimp usedSimps
+      disabledTheorems
+
 end Aesop

--- a/Aesop/Util/Tactic.lean
+++ b/Aesop/Util/Tactic.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Lean.Elab.Tactic
+import Aesop.Util.Basic
 
 open Lean
 open Lean.Elab.Tactic
 open Lean.Meta
+
+namespace Aesop
 
 -- TODO This tactic simply executes the `MetaM` version of `cases`. We need this
 -- when generating tactic scripts because the `MetaM` version and the `TacticM`
@@ -20,3 +22,117 @@ elab &"aesop_cases" x:ident : tactic =>
     let fvarId ← getFVarFromUserName x.getId
     let subgoals ← goal.cases fvarId.fvarId!
     return subgoals.map (·.mvarId) |>.toList
+
+inductive UnfoldResult
+  | unchanged
+  | changed (goal : MVarId) (usedDecls : HashSet Name)
+
+namespace UnfoldResult
+
+def newGoal? : UnfoldResult → Option MVarId
+  | unchanged => none
+  | changed goal _ => some goal
+
+def usedDecls? : UnfoldResult → Option (HashSet Name)
+  | unchanged => none
+  | changed _ usedDecls => some usedDecls
+
+def usedDecls (r : UnfoldResult) : HashSet Name :=
+  r.usedDecls?.getD {}
+
+end UnfoldResult
+
+
+def mkUnfoldSimpContext : MetaM Simp.Context := do
+  return {
+    simpTheorems := #[]
+    congrTheorems := ← getSimpCongrTheorems
+    config := Simp.neutralConfig
+    dischargeDepth := 0
+  }
+
+-- Inspired by Lean.Meta.unfold, Lean.Meta.unfoldTarget,
+-- Lean.Meta.unfoldLocalDecl.
+def _root_.Lean.MVarId.unfoldManyStar (goal : MVarId)
+    (unfold? : Name → Option (Option Name)) : MetaM UnfoldResult :=
+  goal.withContext do
+    let initialGoal := goal
+    let mut goal := goal
+    let usedDecls ← IO.mkRef {}
+    let ctx ← mkUnfoldSimpContext
+
+    let target ← instantiateMVars (← goal.getType)
+    let r ← unfold usedDecls ctx target
+    if (← instantiateMVars r.expr) != target then
+      goal ← applySimpResultToTarget goal target r
+
+    for ldecl in (← goal.getDecl).lctx do
+      let r ← unfold usedDecls ctx (← instantiateMVars ldecl.type)
+      if (← instantiateMVars r.expr) != ldecl.type then
+        let some (_, goal') ←
+          applySimpResultToLocalDecl goal ldecl.fvarId r (mayCloseGoal := false)
+          | unreachable!
+        goal := goal'
+
+    if goal == initialGoal then
+      return .unchanged
+    else
+      return .changed goal (← usedDecls.get)
+  where
+    @[inline]
+    unfold (usedDecls : IO.Ref (HashSet Name)) (ctx : Simp.Context) (e : Expr) :
+        MetaM Simp.Result :=
+      (·.fst) <$>
+        Simp.main e ctx (methods := { pre := pre usedDecls })
+
+    -- NOTE: once we succeed in unfolding something, we return `done`. This
+    -- means that `simp` won't recurse into the unfolded expression, missing
+    -- potential further opportunities for unfolding.
+    --
+    -- I've tried returning
+    -- `visit` instead, in which case we get recursive unfolding as desired, but
+    -- we also get different results than when we call the `unfold` tactic
+    -- multiple times.
+    --
+    -- Aesop calls `unfold` multiple times anyway, so the current implementation
+    -- is slow but correct.
+    pre (usedDecls : IO.Ref (HashSet Name)) (e : Expr) : SimpM Simp.Step := do
+      let some decl := e.getAppFn'.constName?
+        | return .visit { expr := e }
+      match unfold? decl with
+      | none =>
+        return .visit { expr := e }
+      | some none =>
+        if let some e' ← delta? e (λ n => n == decl) then
+          usedDecls.modify (·.insert decl)
+          return .done { expr := e' }
+        else
+          return .visit { expr := e }
+      | some (some unfoldThm) =>
+        let result? ← withReducible <|
+          Simp.tryTheorem? e
+            { origin := .decl unfoldThm
+              proof := mkConst unfoldThm
+              rfl := ← isRflTheorem unfoldThm }
+            (fun _ => return none)
+        match result? with
+        | none   => return .visit { expr := e }
+        | some r =>
+          usedDecls.modify (·.insert decl)
+          match (← reduceMatcher? r.expr) with
+          | .reduced e' => return .done { r with expr := e' }
+          | _ => return .done r
+
+elab &"aesop_unfold " "[" ids:ident,+ "]" : tactic => do
+  let mut toUnfold : HashMap Name (Option Name) := {}
+  for id in (ids : Array Ident) do
+    let decl ← resolveGlobalConstNoOverload id
+    toUnfold := toUnfold.insert decl (← getUnfoldEqnFor? decl)
+
+  liftMetaTactic λ goal => do
+    match ← goal.unfoldManyStar (toUnfold.find? ·) with
+    | .unchanged =>
+      throwTacticEx `aesop_unfold goal "could not unfold any of the given constants"
+    | .changed goal _ => return [goal]
+
+end Aesop

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Next, we prove another simple theorem about `NonEmpty`:
 
 ``` lean
 theorem nil_not_nonEmpty (xs : MyList α) : xs = nil → ¬ NonEmpty xs := by
-  aesop (add 10% cases MyList, norm unfold Not)
+  aesop (add 10% cases MyList, norm simp Not)
 ```
 
 Here we add two rules in an **`add`** clause. These rules are not part of a
@@ -243,10 +243,10 @@ that Aesop applies other rules if possible.
 We also add a **norm** or **normalisation** rule. As mentioned above, these
 rules are used to normalise the goal before any other rules are applied. As part
 of this normalisation process, we run a variant of `simp_all` with the global
-`simp` set plus Aesop-specific `simp` lemmas. The **`unfold`** builder adds such
+`simp` set plus Aesop-specific `simp` lemmas. The **`simp`** builder adds such
 an Aesop-specific `simp` lemma which unfolds the `Not` definition. (There is
 also a built-in rule which performs the same unfolding, so this rule is
-redundant, but I wanted to talk about normalisation rules.)
+redundant.)
 
 Here are some other examples where normalisation comes in handy:
 
@@ -291,7 +291,7 @@ A rule is a tactic plus some associated metadata. Rules come in three flavours:
   the normalisation algorithm.
 
   Normalisation rules can also be simp lemmas. These are constructed with the
-  `unfold` or `simp` builder. They are used by a special `simp` call during
+  `simp` builder. They are used by a special `simp` call during
   the normalisation process.
 
 - **Safe rules** (keyword `safe`) are applied after normalisation but before any
@@ -494,9 +494,15 @@ an Aesop rule. Currently available builders are:
   `eq` as a simp lemma for the built-in simp pass during normalisation. As such,
   this builder can only build normalisation rules.
 - **`unfold`**: when applied to a definition or `let` hypothesis `f`, registers
-  `f` to be unfolded (i.e. replaced with its definition) by the built-in simp
-  pass during normalisation. As such, this builder can only build normalisation
-  rules.
+  `f` to be unfolded (i.e. replaced with its definition) during normalisation.
+  As such, this builder can only build normalisation rules. The unfolding
+  happens in a separate `simp` pass.
+
+  The `simp` builder can also be used to unfold definitions. The difference is
+  that `simp` rules perform smart unfolding (like the `simp` tactic) and
+  `unfold` rules perform non-smart unfolding (like the `unfold` tactic).
+  Non-smart unfolding unfolds functions even when none of their equations
+  match, so `unfold` rules for recursive functions generally lead to looping.
 - **`tactic`**: takes a tactic and directly turns it into a rule. The given
   declaration (the builder does not work for hypotheses) must have type `TacticM
   Unit`, `Aesop.SimpleRuleTac` or `Aesop.RuleTac`. The latter are Aesop data

--- a/tests/run/23.lean
+++ b/tests/run/23.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Aesop
+
+def Involutive (f : α → α) : Prop :=
+  ∀ x, f (f x) = x
+
+example : Involutive not := by
+  aesop (add norm simp Involutive)
+
+example : Involutive not := by
+  aesop (add norm unfold Involutive)

--- a/tests/run/DocLists.lean
+++ b/tests/run/DocLists.lean
@@ -52,7 +52,7 @@ example {α : Type _} {xs : MyList α} ys zs :
   aesop
 
 theorem nil_not_nonEmpty (xs : MyList α) : xs = nil → ¬ NonEmpty xs := by
-  aesop (add unsafe 10% cases MyList, norm unfold Not)
+  aesop (add unsafe 10% cases MyList, norm simp Not)
 
 @[simp]
 theorem append_nil {xs : MyList α} :

--- a/tests/run/List.lean
+++ b/tests/run/List.lean
@@ -89,7 +89,7 @@ instance : Membership α (Option α) :=
 
 @[simp]
 theorem mem_spec {o : Option α} : a ∈ o ↔ o = some a := by
-  aesop (add norm unfold Membership.mem)
+  aesop (add norm simp Membership.mem)
 
 @[simp]
 theorem mem_none : a ∈ none ↔ False := by
@@ -489,7 +489,7 @@ attribute [-simp] cons_subset
 @[simp] theorem X.cons_subset {a : α} {l m : List α} :
   a::l ⊆ m ↔ a ∈ m ∧ l ⊆ m := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold [HasSubset.Subset, List.Subset])
+  aesop (add norm simp [HasSubset.Subset, List.Subset])
 
 theorem cons_subset_of_subset_of_mem {a : α} {l m : List α}
     (ainm : a ∈ m) (lsubm : l ⊆ m) : a::l ⊆ m := by
@@ -498,12 +498,12 @@ theorem cons_subset_of_subset_of_mem {a : α} {l m : List α}
 theorem append_subset_of_subset_of_subset {l₁ l₂ l : List α} (l₁subl : l₁ ⊆ l) (l₂subl : l₂ ⊆ l) :
   l₁ ++ l₂ ⊆ l := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold [HasSubset.Subset, List.Subset])
+  aesop (add norm simp [HasSubset.Subset, List.Subset])
 
 @[simp] theorem append_subset_iff {l₁ l₂ l : List α} :
     l₁ ++ l₂ ⊆ l ↔ l₁ ⊆ l ∧ l₂ ⊆ l := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold [HasSubset.Subset, List.Subset])
+  aesop (add norm simp [HasSubset.Subset, List.Subset])
 
 @[aesop safe destruct]
 theorem eq_nil_of_subset_nil {l : List α} : l ⊆ [] → l = [] := by
@@ -516,7 +516,7 @@ theorem X.eq_nil_iff_forall_not_mem {l : List α} : l = [] ↔ ∀ a, a ∉ l :=
 -- attribute [-simp] map_subset
 theorem X.map_subset {l₁ l₂ : List α} (f : α → β) (H : l₁ ⊆ l₂) : map f l₁ ⊆ map f l₂ := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold [HasSubset.Subset, List.Subset])
+  aesop (add norm simp [HasSubset.Subset, List.Subset])
 
 theorem map_subset_iff {l₁ l₂ : List α} (f : α → β) (h : Injective f) :
     map f l₁ ⊆ map f l₂ ↔ l₁ ⊆ l₂ := by
@@ -661,7 +661,7 @@ theorem replicate_add (a : α) (m n) : replicate (m + n) a = replicate m a ++ re
 
 theorem replicate_subset_singleton (a : α) (n) : replicate n a ⊆ [a] := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold [HasSubset.Subset, List.Subset])
+  aesop (add norm simp [HasSubset.Subset, List.Subset])
 
 theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = replicate n a :=
   ADMIT -- Nontrivial existential.
@@ -705,7 +705,7 @@ theorem replicate_right_injective (a : α) : Injective (λ n => replicate n a) :
 theorem mem_pure {α} (x y : α) :
     x ∈ (pure y : List α) ↔ x = y := by
   set_option aesop.check.script false in -- TODO
-  aesop (add norm unfold pure)
+  aesop (add norm simp pure)
 
 /-! ### bind -/
 
@@ -857,7 +857,7 @@ theorem empty_iff_eq_nil {l : List α} : Empty l ↔ l = [] := by
   | [_] => by aesop
   | (_ :: y :: zs) => by
     have ih := length_init (y :: zs)
-    aesop (add norm unfold [init], norm simp [Nat.add_sub_cancel])
+    aesop (add norm simp [init, Nat.add_sub_cancel])
 
 /-! ### last -/
 
@@ -886,14 +886,14 @@ theorem init_append_last : ∀ {l : List α} (h : l ≠ []), init l ++ [last l h
   | [_] => by aesop
   | x :: y :: zs => by
     have ih := init_append_last (l := y :: zs)
-    aesop (add norm unfold [init, last])
+    aesop (add norm simp [init, last])
 
 theorem last_congr {l₁ l₂ : List α} (h₁ : l₁ ≠ []) (h₂ : l₂ ≠ []) (h₃ : l₁ = l₂) :
   last l₁ h₁ = last l₂ h₂ := by
   aesop
 
 theorem last_mem : ∀ {l : List α} (h : l ≠ []), last l h ∈ l := by
-  intro l; induction l <;> aesop (add norm unfold last, 1% cases List)
+  intro l; induction l <;> aesop (add norm simp last, 1% cases List)
 
 theorem last_replicate_succ (a m : Nat) :
   (replicate m.succ a).last
@@ -924,7 +924,7 @@ theorem mem_last'_eq_last : ∀ {l : List α} {x : α}, x ∈ l.last' → ∃ h,
   | [_], _, h => by aesop
   | a :: a' :: as, x, h => by
     have ih := mem_last'_eq_last (l := a' :: as) (x := x)
-    aesop (add norm unfold last')
+    aesop (add norm simp last')
 
 theorem last'_eq_last_of_ne_nil : ∀ {l : List α} (h : l ≠ []), l.last' = some (l.last h)
   | [], h => by aesop
@@ -949,7 +949,7 @@ theorem init_append_last' : ∀ {l : List α} {a}, a ∈ l.last' → init l ++ [
   | [_], _ => by aesop
   | x :: y :: zs, a => by
     have ih := init_append_last' (l := y :: zs) (a := a)
-    aesop (add norm unfold init)
+    aesop (add norm simp init)
 
 theorem ilast_eq_last' [Inhabited α] : ∀ l : List α, l.ilast = l.last'.iget
   | [] => by aesop

--- a/tests/run/Unfold.lean
+++ b/tests/run/Unfold.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2023 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+-- Inspired by this Zulip discussion:
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Goal.20state.20not.20updating.2C.20bugs.2C.20etc.2E/near/338356062
+
+import Aesop
+
+-- TODO add to builtin rule set
+attribute [aesop safe cases] Empty
+
+structure WalkingPair
+
+def WidePullbackShape A B := Sum A B
+
+abbrev WalkingCospan : Type := WidePullbackShape Empty Empty
+
+@[aesop norm destruct]
+theorem WalkingCospan_elim : WalkingCospan → Sum Empty Empty := id
+
+example (h : WalkingCospan) : α := by
+  aesop (add norm unfold [WidePullbackShape, WalkingCospan])
+
+example (h : WalkingCospan) : α := by
+  aesop (add norm simp [WidePullbackShape, WalkingCospan])


### PR DESCRIPTION
@Kha I finally got around to fixing the smart unfolding issue. A `simp` rule for a declaration `d` now adds `d` to the `simp` set like `@[simp] d` would. An `unfold` rule for `d` now unfolds `d` without smart unfolding.

`unfold` rules are implemented by a new `simp` pass in the normalisation phase, inspired by the `simp` used in the `unfold` tactic. The implementation is in `Aesop/Util/Tactic.lean`. Could you maybe take a look at this? (The rest of this PR is just scaffolding.)

One question is whether the `unfold` `simp` pass should recurse into the unfolded expressions. The `unfold` tactic does not do this, but as a result, it may miss unfoldable expressions, depending on the order of its arguments. So I'm tempted to allow such recursion. The downside is that `unfold` then cannot be used with recursive definitions at all. But `unfold` is generally too aggressive when unfolding recursive definitions anyway, so maybe that's okay.

fixes #23