### PR TITLE
Completely disable prebuilt releases

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,8 +4,6 @@ open Lake DSL
 
 package aesop {
   precompileModules := true
-  preferReleaseBuild := true
-  buildArchive? := some "aesop"
 }
 
 @[default_target]


### PR DESCRIPTION
The half-enabled releases only cause warnings downstream.

> `warning: wanted prebuilt release, but release repository and tag was not known`