### PR TITLE
Remove blanket imports of Std or Lean

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,7 @@ jobs:
         echo "$HOME/.elan/bin" >> $GITHUB_PATH
     - name: Build
       run: lake build
+    - name: Build std4
+      run: lake build Std
     - name: Run tests
       run: ./test

--- a/Aesop/Builder/Basic.lean
+++ b/Aesop/Builder/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 
 import Aesop.Rule
-import Lean
 
 open Lean
 open Lean.Meta

--- a/Aesop/Check.lean
+++ b/Aesop/Check.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Lean
+import Lean.Data.Options
 
 open Lean
 

--- a/Aesop/Options.lean
+++ b/Aesop/Options.lean
@@ -1,9 +1,3 @@
-import Lean
-
-open Lean
-open Lean.Meta
-open Lean.Elab.Term
-
 namespace Aesop
 
 inductive Strategy

--- a/Aesop/RuleTac/Basic.lean
+++ b/Aesop/RuleTac/Basic.lean
@@ -8,6 +8,7 @@ import Aesop.Index.Basic
 import Aesop.Rule.BranchState
 import Aesop.Script
 import Aesop.Util
+import Std.Lean.Meta.SavedState
 
 open Lean
 open Lean.Elab.Tactic

--- a/Aesop/RuleTac/Forward.lean
+++ b/Aesop/RuleTac/Forward.lean
@@ -5,6 +5,8 @@ Authors: Jannis Limperg
 -/
 
 import Aesop.RuleTac.Basic
+import Std.Lean.Meta.UnusedNames
+import Std.Lean.Meta.AssertHypotheses
 
 open Lean
 open Lean.Meta

--- a/Aesop/Script.lean
+++ b/Aesop/Script.lean
@@ -5,6 +5,8 @@ Authors: Jannis Limperg
 -/
 
 import Aesop.Util
+import Std.Lean.Meta.Clear
+import Std.Lean.Meta.Inaccessible
 
 open Lean
 open Lean.Elab.Tactic

--- a/Aesop/Search/Queue.lean
+++ b/Aesop/Search/Queue.lean
@@ -8,7 +8,7 @@ import Aesop.Options
 import Aesop.Tracing
 import Aesop.Tree
 import Aesop.Search.Queue.Class
-import Std
+import Std.Data.BinomialHeap
 
 open Lean
 open Std (BinomialHeap)

--- a/Aesop/Tracing.lean
+++ b/Aesop/Tracing.lean
@@ -5,6 +5,7 @@ Authors: Jannis Limperg
 -/
 
 import Aesop.Tracing.Init
+import Lean.Parser.Do
 
 open Lean
 

--- a/Aesop/Tracing/Init.lean
+++ b/Aesop/Tracing/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Lean
+import Lean.Data.Options
 
 open Lean
 

--- a/Aesop/Util/Basic.lean
+++ b/Aesop/Util/Basic.lean
@@ -6,8 +6,7 @@ Authors: Jannis Limperg, Asta Halkjær From
 
 import Aesop.Nanos
 import Aesop.Util.UnionFind
-import Lean
-import Std
+import Std.Lean.Meta.InstantiateMVars
 
 
 def BEq.ofOrd (ord : Ord α) : BEq α where

--- a/Aesop/Util/Tactic.lean
+++ b/Aesop/Util/Tactic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Lean
+import Lean.Elab.Tactic
 
 open Lean
 open Lean.Elab.Tactic

--- a/Aesop/Util/UnionFind.lean
+++ b/Aesop/Util/UnionFind.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Std
+import Std.Data.HashMap
 
 open Std (HashMap)
 

--- a/tests/run/Aesop.lean
+++ b/tests/run/Aesop.lean
@@ -6,6 +6,10 @@ Authors: Jannis Limperg
 
 import Aesop
 
+-- make sure definitions don't clash
+import Lean
+import Std
+
 set_option aesop.check.all true
 
 open Lean


### PR DESCRIPTION
`import Std` makes it really hard to try changes in std4 when debugging things in mathlib4.  This is only going to get worse as Mario moves all of mathlib into std.