### PR TITLE
Remove overlapping BEq instance

### DIFF
--- a/Aesop/Search/SearchM.lean
+++ b/Aesop/Search/SearchM.lean
@@ -63,10 +63,10 @@ instance : MonadLift TreeM (SearchM Q) where
     let ctx := { currentIteration := (← get).iteration }
     liftM $ ReaderT.run x ctx
 
-instance (priority := high) : MonadState (State Q) (SearchM Q) :=
+instance : MonadState (State Q) (SearchM Q) :=
   { inferInstanceAs (MonadStateOf (State Q) (SearchM Q)) with }
 
-instance (priority := high) : MonadReader Context (SearchM Q) :=
+instance : MonadReader Context (SearchM Q) :=
   { inferInstanceAs (MonadReaderOf Context (SearchM Q)) with }
 
 instance : MonadReaderOf ProfileT.Context (SearchM Q) where

--- a/Aesop/Tree/TreeM.lean
+++ b/Aesop/Tree/TreeM.lean
@@ -66,7 +66,7 @@ namespace TreeM
 instance : Monad TreeM :=
   { inferInstanceAs (Monad TreeM) with }
 
-instance (priority := low) : Inhabited (TreeM α) where
+instance : Inhabited (TreeM α) where
   default := failure
 
 def run' (ctx : TreeM.Context) (t : Tree) (x : TreeM α) :

--- a/Aesop/Util/Basic.lean
+++ b/Aesop/Util/Basic.lean
@@ -16,10 +16,6 @@ def BEq.ofOrd (ord : Ord α) : BEq α where
     | Ordering.eq => true
     | _ => false
 
-instance (priority := low) [ord : Ord α] : BEq α :=
-  BEq.ofOrd ord
-
-
 namespace Option
 
 def toArray : Option α → Array α
@@ -227,7 +223,7 @@ def deduplicateSorted [eq : BEq α] (xs : Array α) : Array α :=
   xs.mergeAdjacentDuplicates (λ x _ => x)
 
 set_option linter.unusedVariables false in
-def deduplicate [Inhabited α] [ord : Ord α] (xs : Array α) : Array α :=
+def deduplicate [Inhabited α] [BEq α] [ord : Ord α] (xs : Array α) : Array α :=
   deduplicateSorted $ xs.qsort λ x y => compare x y |>.isLT
 
 def equalSet [BEq α] (xs ys : Array α) : Bool :=


### PR DESCRIPTION
I've also removed all the other priority annotations on instances.  Those were unnecessary and just gave a false sense of utility.  Don't use instance priorities unless you absolutely know what you're doing, can clearly explain why they're necessary, have verified that it doesn't work without, and added a comment documenting that fact!