### PR TITLE
Fix spacing in grammar

### DIFF
--- a/Aesop/BuiltinRules/DestructProducts.lean
+++ b/Aesop/BuiltinRules/DestructProducts.lean
@@ -80,7 +80,7 @@ partial def destructProductsCore (goal : MVarId) : MetaM MVarId :=
         else
           return goal
 
-elab &"aesop_destruct_products" : tactic =>
+elab "aesop_destruct_products" : tactic =>
   Elab.Tactic.liftMetaTactic1 λ goal => some <$> destructProductsCore goal
 
 -- This tactic splits hypotheses of product-like types: `And`, `Prod`, `PProd`,

--- a/Aesop/BuiltinRules/Split.lean
+++ b/Aesop/BuiltinRules/Split.lean
@@ -31,7 +31,7 @@ def splitFirstHypothesis (goal : MVarId) : MetaM (Option (Array MVarId)) :=
 def splitHypothesesCore (goal : MVarId) : MetaM (Option (Array MVarId)) :=
   saturate1 goal splitFirstHypothesis
 
-elab &"aesop_split_hyps" : tactic =>
+elab "aesop_split_hyps" : tactic =>
   Elab.Tactic.liftMetaTactic λ goal => do
     match ← splitHypothesesCore goal with
     | none => throwError "no splittable hypothesis found"

--- a/Aesop/BuiltinRules/Subst.lean
+++ b/Aesop/BuiltinRules/Subst.lean
@@ -71,10 +71,10 @@ def elabAesopSubst (hyps : Array Syntax.Ident) : TacticM Unit := do
     else
       return [goal]
 
-elab &"aesop_subst " "[" hyps:ident,+ "]" : tactic =>
+elab "aesop_subst " "[" hyps:ident,+ "]" : tactic =>
   elabAesopSubst hyps
 
-elab &"aesop_subst " hyp:ident : tactic =>
+elab "aesop_subst " hyp:ident : tactic =>
   elabAesopSubst #[hyp]
 
 @[aesop (rule_sets [builtin]) norm -50

--- a/Aesop/Frontend/Attribute.lean
+++ b/Aesop/Frontend/Attribute.lean
@@ -19,7 +19,7 @@ declare_syntax_cat Aesop.attr_rules
 syntax Aesop.rule_expr : Aesop.attr_rules
 syntax "[" Aesop.rule_expr,+,? "]" : Aesop.attr_rules
 
-syntax (name := aesop) &"aesop" Aesop.attr_rules : attr
+syntax (name := aesop) "aesop" Aesop.attr_rules : attr
 
 end Parser
 

--- a/Aesop/Frontend/Command.lean
+++ b/Aesop/Frontend/Command.lean
@@ -11,12 +11,12 @@ open Lean
 namespace Aesop.Frontend.Parser
 
 open Elab.Command in
-elab "declare_aesop_rule_sets" "[" ids:ident,+,? "]" : command => do
+elab "declare_aesop_rule_sets " "[" ids:ident,+,? "]" : command => do
   let rsNames := (ids : Array Ident).map (·.getId)
   rsNames.forM checkRuleSetNotDeclared
   elabCommand $ ← `(initialize ($(quote rsNames).forM declareRuleSetUnchecked))
 
-elab "erase_aesop_rules" "[" es:Aesop.rule_expr,* "]" : command => do
+elab "erase_aesop_rules " "[" es:Aesop.rule_expr,* "]" : command => do
   let filters ← (es : Array _).mapM λ e => do
     let e ← Elab.Command.liftTermElabM $
       RuleExpr.elab e |>.run ElabOptions.forErasing

--- a/Aesop/Frontend/RuleExpr.lean
+++ b/Aesop/Frontend/RuleExpr.lean
@@ -74,9 +74,9 @@ namespace Parser
 
 declare_syntax_cat Aesop.phase (behavior := symbol)
 
-syntax &"safe" : Aesop.phase
-syntax &"norm" : Aesop.phase
-syntax &"unsafe" : Aesop.phase
+syntax "safe" : Aesop.phase
+syntax "norm" : Aesop.phase
+syntax "unsafe" : Aesop.phase
 
 end Parser
 
@@ -93,8 +93,8 @@ namespace Parser
 
 declare_syntax_cat Aesop.bool_lit (behavior := symbol)
 
-syntax &"true" : Aesop.bool_lit
-syntax &"false" : Aesop.bool_lit
+syntax "true" : Aesop.bool_lit
+syntax "false" : Aesop.bool_lit
 
 end Parser
 
@@ -110,15 +110,15 @@ namespace Parser
 
 declare_syntax_cat Aesop.builder_name (behavior := symbol)
 
-syntax &"apply" : Aesop.builder_name
-syntax &"simp" : Aesop.builder_name
-syntax &"unfold" : Aesop.builder_name
-syntax &"tactic" : Aesop.builder_name
-syntax &"constructors" : Aesop.builder_name
-syntax &"forward" : Aesop.builder_name
-syntax &"destruct" : Aesop.builder_name
-syntax &"cases" : Aesop.builder_name
-syntax &"default" : Aesop.builder_name
+syntax "apply" : Aesop.builder_name
+syntax "simp" : Aesop.builder_name
+syntax "unfold" : Aesop.builder_name
+syntax "tactic" : Aesop.builder_name
+syntax "constructors" : Aesop.builder_name
+syntax "forward" : Aesop.builder_name
+syntax "destruct" : Aesop.builder_name
+syntax "cases" : Aesop.builder_name
+syntax "default" : Aesop.builder_name
 
 end Parser
 
@@ -159,9 +159,9 @@ namespace Parser
 
 declare_syntax_cat Aesop.indexing_mode (behavior := symbol)
 
-syntax &"target " term : Aesop.indexing_mode
-syntax &"hyp " term : Aesop.indexing_mode
-syntax &"unindexed " : Aesop.indexing_mode
+syntax "target " term : Aesop.indexing_mode
+syntax "hyp " term : Aesop.indexing_mode
+syntax "unindexed " : Aesop.indexing_mode
 
 end Parser
 
@@ -217,12 +217,12 @@ namespace Parser
 
 declare_syntax_cat Aesop.builder_option
 
-syntax "(" &"uses_branch_state" ":=" Aesop.bool_lit ")" : Aesop.builder_option
-syntax "(" &"immediate" ":=" "[" ident,+,? "]" ")" : Aesop.builder_option
-syntax "(" &"index" ":=" "[" Aesop.indexing_mode,+,? "]" ")" : Aesop.builder_option
-syntax "(" &"patterns" ":=" "[" term,+,? "]" ")" : Aesop.builder_option
-syntax "(" &"transparency" ":=" transparency ")" : Aesop.builder_option
-syntax "(" &"transparency!" ":=" transparency ")" : Aesop.builder_option
+syntax " (" &"uses_branch_state" " := " Aesop.bool_lit ")" : Aesop.builder_option
+syntax " (" &"immediate" " := " "[" ident,+,? "]" ")" : Aesop.builder_option
+syntax " (" &"index" " := " "[" Aesop.indexing_mode,+,? "]" ")" : Aesop.builder_option
+syntax " (" &"patterns" " := " "[" term,+,? "]" ")" : Aesop.builder_option
+syntax " (" &"transparency" " := " transparency ")" : Aesop.builder_option
+syntax " (" &"transparency!" " := " transparency ")" : Aesop.builder_option
 
 syntax builderOptions := Aesop.builder_option*
 
@@ -442,7 +442,7 @@ end Builder
 
 namespace Parser
 
-syntax ruleSetsFeature := "(" &"rule_sets" "[" ident,+,? "]" ")"
+syntax ruleSetsFeature := "(" &"rule_sets " "[" ident,+,? "]" ")"
 
 end Parser
 
@@ -540,8 +540,8 @@ namespace Parser
 declare_syntax_cat Aesop.rule_expr (behavior := symbol)
 
 syntax Aesop.feature : Aesop.rule_expr
-syntax Aesop.feature Aesop.rule_expr : Aesop.rule_expr
-syntax Aesop.feature "[" Aesop.rule_expr,+,? "]" : Aesop.rule_expr
+syntax Aesop.feature ppSpace Aesop.rule_expr : Aesop.rule_expr
+syntax Aesop.feature " [" Aesop.rule_expr,+,? "]" : Aesop.rule_expr
 
 end Parser
 

--- a/Aesop/Frontend/Tactic.lean
+++ b/Aesop/Frontend/Tactic.lean
@@ -20,14 +20,14 @@ declare_syntax_cat Aesop.tactic_clause
 
 syntax ruleSetSpec := "-"? ident
 
-syntax "(" &"add" Aesop.rule_expr,+,? ")" : Aesop.tactic_clause
-syntax "(" &"erase" Aesop.rule_expr,+,? ")" : Aesop.tactic_clause
-syntax "(" &"rule_sets" "[" ruleSetSpec,+,? "]" ")" : Aesop.tactic_clause
-syntax "(" &"options" ":=" term ")" : Aesop.tactic_clause
-syntax "(" &"simp_options" ":=" term ")" : Aesop.tactic_clause
+syntax " (" &"add " Aesop.rule_expr,+,? ")" : Aesop.tactic_clause
+syntax " (" &"erase " Aesop.rule_expr,+,? ")" : Aesop.tactic_clause
+syntax " (" &"rule_sets " "[" ruleSetSpec,+,? "]" ")" : Aesop.tactic_clause
+syntax " (" &"options" " := " term ")" : Aesop.tactic_clause
+syntax " (" &"simp_options" " := " term ")" : Aesop.tactic_clause
 
-syntax (name := aesopTactic) &"aesop" Aesop.tactic_clause* : tactic
-syntax (name := aesopTactic?) &"aesop?" Aesop.tactic_clause* : tactic
+syntax (name := aesopTactic)  "aesop"  Aesop.tactic_clause* : tactic
+syntax (name := aesopTactic?) "aesop?" Aesop.tactic_clause* : tactic
 
 end Parser
 

--- a/Aesop/Script.lean
+++ b/Aesop/Script.lean
@@ -18,7 +18,7 @@ open Lean.PrettyPrinter
 namespace Aesop
 
 -- FIXME remove
-elab (name := Parser.onGoal) &"on_goal " n:num " => " ts:tacticSeq : tactic => do
+elab (name := Parser.onGoal) "on_goal " n:num " => " ts:tacticSeq : tactic => do
   let gs := (← getGoals).toArray
   let n := n.getNat
   if n == 0 then

--- a/Aesop/Tracing.lean
+++ b/Aesop/Tracing.lean
@@ -77,7 +77,7 @@ def resolveTraceOption (stx : Ident) : MacroM Name :=
     else
       return n
 
-macro "aesop_trace![" opt:ident "]" msg:(interpolatedStr(term) <|> term) :
+macro "aesop_trace![" opt:ident "] " msg:(interpolatedStr(term) <|> term) :
     doElem => do
   let opt ← mkIdent <$> resolveTraceOption opt
   let msg := msg.raw
@@ -87,7 +87,7 @@ macro "aesop_trace![" opt:ident "]" msg:(interpolatedStr(term) <|> term) :
     `(toMessageData ($(⟨msg⟩)))
   `(doElem| Lean.addTrace (Aesop.TraceOption.traceClass $opt) $msg)
 
-macro "aesop_trace[" opt:ident "]"
+macro "aesop_trace[" opt:ident "] "
     msg:(interpolatedStr(term) <|> Parser.Term.do <|> term) : doElem => do
   let msg := msg.raw
   let opt ← mkIdent <$> resolveTraceOption opt

--- a/Aesop/Util/Tactic.lean
+++ b/Aesop/Util/Tactic.lean
@@ -17,7 +17,7 @@ namespace Aesop
 -- version of `cases` use different naming heuristics. If the two tactics were
 -- harmonised, we could use regular `cases` in the script (assuming there are no
 -- other differences).
-elab &"aesop_cases" x:ident : tactic =>
+elab "aesop_cases " x:ident : tactic =>
   liftMetaTactic λ goal => do
     let fvarId ← getFVarFromUserName x.getId
     let subgoals ← goal.cases fvarId.fvarId!
@@ -122,7 +122,7 @@ def _root_.Lean.MVarId.unfoldManyStar (goal : MVarId)
           | .reduced e' => return .done { r with expr := e' }
           | _ => return .done r
 
-elab &"aesop_unfold " "[" ids:ident,+ "]" : tactic => do
+elab "aesop_unfold " "[" ids:ident,+ "]" : tactic => do
   let mut toUnfold : HashMap Name (Option Name) := {}
   for id in (ids : Array Ident) do
     let decl ← resolveGlobalConstNoOverload id

--- a/AesopTest/Forward.lean
+++ b/AesopTest/Forward.lean
@@ -12,8 +12,8 @@ open Aesop Lean Lean.Meta Lean.Elab.Tactic
 
 /-! # Unit tests for the MetaM tactic that implements forward rules -/
 
-syntax (name := forward) &"forward" ident ("[" ident* "]")? : tactic
-syntax (name := elim)    &"elim"    ident ("[" ident* "]")? : tactic
+syntax (name := forward) "forward " ident (" [" ident* "]")? : tactic
+syntax (name := elim)    "elim "    ident (" [" ident* "]")? : tactic
 
 def forwardTac (goal : MVarId) (id : Syntax) (immediate : Option (Array Syntax))
     (clear : Bool) (md : TransparencyMode) : MetaM (List MVarId) := do

--- a/AesopTest/RuleSetNameHygiene1.lean
+++ b/AesopTest/RuleSetNameHygiene1.lean
@@ -8,7 +8,7 @@ import AesopTest.RuleSetNameHygiene0
 
 set_option aesop.check.all true
 
-macro &"aesop_test" : tactic => `(tactic| aesop (rule_sets [test]))
+macro "aesop_test" : tactic => `(tactic| aesop (rule_sets [test]))
 
 @[aesop safe (rule_sets [test])]
 structure TT


### PR DESCRIPTION
Adds spaces to affect the pretty printing of the `aesop` tactic.