### PR TITLE
chore: bump to nightly-2023-08-19

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-17
+leanprover/lean4:nightly-2023-08-19


### PR DESCRIPTION
I wouldn't usually do a trivial bump to a nightly, but `nightly-2023-08-19` is the tentative release candidate for the first official release of Lean 4, so we would like to try everything out on it.