### PR TITLE
fix: use replay from leanprover/lean4#2617

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc1
+leanprover/lean4-pr-releases:pr-release-2617


### PR DESCRIPTION
This is only relevant after leanprover/lean4#2617 is merged.

This PR uses `Environment.replay` instead of the playing-with-fire `Environment.add` which we would like to make private.