### PR TITLE
Index: stabilise ordering of index match locations and pattern substitutions

### DIFF
--- a/Aesop/BuiltinRules/Subst.lean
+++ b/Aesop/BuiltinRules/Subst.lean
@@ -89,7 +89,7 @@ meta def substEqsAndIffs? (goal : MVarId) (fvarIds : Array FVarId) :
 @[aesop (rule_sets := [builtin]) norm -50 tactic (index := [hyp _ = _, hyp _ ↔ _])]
 meta def subst : RuleTac := RuleTac.ofSingleRuleTac λ input =>
   input.goal.withContext do
-    let hyps ← input.indexMatchLocations.toArray.mapM λ
+    let hyps ← input.indexMatchLocations.mapM λ
       | .hyp ldecl => pure ldecl.fvarId
       | _ => throwError "unexpected index match location"
     let (some goal, steps) ← substEqsAndIffs? input.goal hyps |>.run

--- a/Aesop/Index/RulePattern.lean
+++ b/Aesop/Index/RulePattern.lean
@@ -6,6 +6,7 @@ Authors: Jannis Limperg
 module
 
 public import Aesop.RulePattern
+public import Aesop.Util.OrderedHashSet
 import Aesop.Index.DiscrTreeConfig
 import Batteries.Lean.Meta.DiscrTree
 
@@ -19,7 +20,7 @@ namespace Aesop
 
 /-- A map from rule names to rule pattern substitutions. When run on a goal,
 the rule pattern index returns such a map. -/
-abbrev RulePatternSubstMap := Std.HashMap RuleName (Std.HashSet Substitution)
+abbrev RulePatternSubstMap := Std.HashMap RuleName (OrderedHashSet Substitution)
 
 namespace RulePatternSubstMap
 
@@ -29,7 +30,7 @@ def insertArray (xs : Array (RuleName × Substitution))
     (m : RulePatternSubstMap) : RulePatternSubstMap :=
   xs.foldl (init := m) λ m (r, inst) =>
     match m[r]? with
-    | none => m.insert r $ (∅ : Std.HashSet _).insert inst
+    | none => m.insert r $ (∅ : OrderedHashSet _).insert inst
     | some insts => m.insert r $ insts.insert inst
 
 /-- Build a rule pattern substitution map from an array of substitutions. -/
@@ -39,7 +40,7 @@ def ofArray (xs : Array (RuleName × Substitution)) : RulePatternSubstMap :=
 /-- Convert a rule pattern substitution map to a flat array of substitutions. -/
 def toFlatArray (m : RulePatternSubstMap) : Array (RuleName × Substitution) :=
   m.fold (init := #[]) λ acc r patInsts =>
-    patInsts.fold (init := acc) λ acc patInst =>
+    patInsts.foldl (init := acc) λ acc patInst =>
       acc.push (r, patInst)
 
 end RulePatternSubstMap

--- a/Aesop/RuleTac/Apply.lean
+++ b/Aesop/RuleTac/Apply.lean
@@ -37,7 +37,7 @@ def applyExpr' (goal : MVarId) (e : Expr) (eStx : Term)
     }
 
 def applyExpr (goal : MVarId) (e : Expr) (eStx : Term)
-    (patSubsts? : Option (Std.HashSet Substitution)) (md : TransparencyMode) :
+    (patSubsts? : Option (Array Substitution)) (md : TransparencyMode) :
     BaseM RuleTacOutput := do
   if let some patSubsts := patSubsts? then
     let mut rapps := Array.mkEmpty patSubsts.size

--- a/Aesop/RuleTac/Basic.lean
+++ b/Aesop/RuleTac/Basic.lean
@@ -28,8 +28,9 @@ structure RuleTacInput where
   /-- The set of mvars that `goal` depends on. -/
   mvars : UnorderedArraySet MVarId
   /-- If the rule is indexed, the locations (i.e. hyps or the target) matched by
-  the rule's index entries. Otherwise an empty set. -/
-  indexMatchLocations : Std.HashSet IndexMatchLocation
+  the rule's index entries. Otherwise an empty set. The array contains no
+  duplicates. -/
+  indexMatchLocations : Array IndexMatchLocation
   /-- If the rule has a pattern, the pattern substitutions that were found in
   the goal. Each substitution is a list of expressions which were found by
   matching the pattern against expressions in the goal. For example, if `h : max
@@ -37,8 +38,8 @@ structure RuleTacInput where
   will be two substitutions `{x ↦ a, y ↦ b}`) and `{x ↦ a, y ↦ c}`.
 
   If the rule does not have a pattern, this is `none`. Otherwise it is
-  guaranteed to be `some xs` with `xs` non-empty. -/
-  patternSubsts? : Option (Std.HashSet Substitution)
+  guaranteed to be `some xs` with `xs` non-empty and duplicate-free. -/
+  patternSubsts? : Option (Array Substitution)
   /-- The options given to Aesop. -/
   options : Options'
   /-- Normalised types of all non-implementation detail hypotheses in the local

--- a/Aesop/RuleTac/Forward.lean
+++ b/Aesop/RuleTac/Forward.lean
@@ -126,7 +126,7 @@ where
   tacticBuilder _ := Script.TacticBuilder.assertHypothesis goal hyp .reducible
 
 def applyForwardRule (goal : MVarId) (e : Expr)
-    (patSubsts? : Option (Std.HashSet Substitution))
+    (patSubsts? : Option (Array Substitution))
     (immediate : UnorderedArraySet PremiseIndex) (clear : Bool)
     (maxDepth? : Option Nat) (existingHypTypes : PHashSet RPINF) :
     ScriptM Subgoal :=

--- a/Aesop/Search/Expansion.lean
+++ b/Aesop/Search/Expansion.lean
@@ -56,8 +56,8 @@ def isSuccessfulOrPostponed
 end SafeRuleResult
 
 def runRegularRuleTac (goal : Goal) (tac : RuleTac) (ruleName : RuleName)
-    (indexMatchLocations : Std.HashSet IndexMatchLocation)
-    (patternSubsts? : Option (Std.HashSet Substitution))
+    (indexMatchLocations : Array IndexMatchLocation)
+    (patternSubsts? : Option (Array Substitution))
     (options : Options') (hypTypes : PHashSet RPINF) :
     BaseM (Except Exception RuleTacOutput) := do
   let some (postNormGoal, postNormState) := goal.postNormGoalAndMetaState? | throwError
@@ -116,8 +116,8 @@ def withRuleTraceNode (ruleName : RuleName)
       return m!"{emoji} {ruleName}{suffix}"
 
 def runRegularRuleCore (parentRef : GoalRef) (rule : RegularRule)
-    (indexMatchLocations : Std.HashSet IndexMatchLocation)
-    (patternSubsts? : Option (Std.HashSet Substitution)) :
+    (indexMatchLocations : Array IndexMatchLocation)
+    (patternSubsts? : Option (Array Substitution)) :
     SearchM Q (Option RuleTacOutput) := do
   let parent ← parentRef.get
   let ruleOutput? ←

--- a/Aesop/Util/OrderedHashSet.lean
+++ b/Aesop/Util/OrderedHashSet.lean
@@ -1,0 +1,74 @@
+module
+
+public import Std.Data.HashSet.Lemmas
+
+public section
+
+open Std (HashSet)
+
+namespace Aesop
+
+/-- A hash set that preserves the order of insertions. -/
+structure OrderedHashSet (α) [BEq α] [Hashable α] where
+  toArray : Array α
+  toHashSet : HashSet α
+  deriving Inhabited
+
+namespace OrderedHashSet
+
+variable [BEq α] [Hashable α]
+
+instance : EmptyCollection (OrderedHashSet α) :=
+  ⟨⟨#[], ∅⟩⟩
+
+def emptyWithCapacity (n : Nat) : OrderedHashSet α where
+  toArray := Array.emptyWithCapacity n
+  toHashSet := HashSet.emptyWithCapacity n
+
+def insert (x : α) (s : OrderedHashSet α) : OrderedHashSet α :=
+  if x ∈ s.toHashSet then
+    s
+  else {
+    toArray := s.toArray.push x
+    toHashSet := s.toHashSet.insert x
+  }
+
+def insertMany [ForIn Id ρ α] (xs : ρ) (s : OrderedHashSet α) :
+    OrderedHashSet α := Id.run do
+  let mut result := s
+  for x in xs do
+    result := result.insert x
+  return result
+
+def ofArray (xs : Array α) : OrderedHashSet α :=
+  (∅ : OrderedHashSet α).insertMany xs
+
+def contains (x : α) (s : OrderedHashSet α) : Bool :=
+  s.toHashSet.contains x
+
+instance : Membership α (OrderedHashSet α) where
+  mem s x := x ∈ s.toHashSet
+
+instance {s : OrderedHashSet α} : Decidable (x ∈ s) :=
+  inferInstanceAs (Decidable (x ∈ s.toHashSet))
+
+@[specialize]
+def foldlM [Monad m] (f : β → α → m β) (init : β)
+    (s : OrderedHashSet α) : m β :=
+  s.toArray.foldlM f init
+
+def foldl (f : β → α → β) (init : β) (s : OrderedHashSet α) : β :=
+  s.toArray.foldl f init
+
+@[specialize]
+def foldrM [Monad m] (f : α → β → m β) (init : β)
+    (s : OrderedHashSet α) : m β :=
+  s.toArray.foldrM f init
+
+def foldr (f : α → β → β) (init : β) (s : OrderedHashSet α) : β :=
+  s.toArray.foldr f init
+
+instance : ForIn m (OrderedHashSet α) α where
+  forIn s b f := ForIn.forIn s.toArray b f
+
+end Aesop.OrderedHashSet

--- a/AesopTest/RulePattern.lean
+++ b/AesopTest/RulePattern.lean
@@ -18,17 +18,14 @@ macro "falso" : tactic => `(tactic| exact falso)
 @[aesop norm -100 forward (pattern := (↑n : Int))]
 axiom nat_pos (n : Nat) : 0 ≤ (↑n : Int)
 
--- The naming of the introduced hypotheses `fwd` and `fwd_1` is not stable,
--- and seems to flip every time we change the toolchain.
--- Could this test be made more robust?
--- example (m n : Nat) : (↑m : Int) < 0 ∧ (↑n : Int) > 0 := by
---   set_option aesop.check.script.steps false in -- TODO lean4#4315
---   set_option aesop.check.script false in
---   aesop (config := { enableSimp := false, warnOnNonterminal := false })
---   all_goals
---     guard_hyp fwd   : 0 ≤ (n : Int)
---     guard_hyp fwd_1 : 0 ≤ (m : Int)
---     falso
+example (m n : Nat) : (↑m : Int) < 0 ∧ (↑n : Int) > 0 := by
+  set_option aesop.check.script.steps false in -- TODO lean4#4315
+  set_option aesop.check.script false in
+  aesop (config := { enableSimp := false, warnOnNonterminal := false })
+  all_goals
+    guard_hyp fwd   : 0 ≤ (m : Int)
+    guard_hyp fwd_1 : 0 ≤ (n : Int)
+    falso
 
 @[aesop safe forward (pattern := min x y)]
 axiom foo : ∀ {x y : Nat} (_ : 0 < x) (_ : 0 < y), 0 < min x y
@@ -44,15 +41,6 @@ notation "|" t "|" => abs t
 
 @[aesop safe forward (pattern := |a + b|)]
 axiom triangle (a b : Int) : |a + b| ≤ |a| + |b|
-
--- The naming of the introduced hypotheses `fwd` and `fwd_1` is not stable,
--- and seems to flip every time we change the toolchain.
--- Could this test be made more robust?
--- example : |a + b| ≤ |c + d| := by
---   aesop!
---   guard_hyp fwd_1 : |a + b| ≤ |a| + |b|
---   guard_hyp fwd : |c + d| ≤ |c| + |d|
---   falso
 
 @[aesop safe apply (pattern := (0 : Nat))]
 axiom falso' : True → False


### PR DESCRIPTION
Prior to this commit, when a rule matched a goal with multiple index
match locations (e.g. multiple hypotheses) or multiple pattern
substitutions, the order of the locations/substitutions was partly based
on (hashes of) FVarId and MVarId names, hence unstable wrt the
'observable' local context.

To fix this, fvar match locations are now ordered by the fvar's index in
the current goal. Pattern substitutions are returned in lookup order by
the rule pattern discrimination tree, which is not ideal but better than
before.

fixes #264
