### PR TITLE
Require tactic clauses to be indented

### DIFF
--- a/AesopTest/Aesop.lean
+++ b/AesopTest/Aesop.lean
@@ -80,10 +80,3 @@ end Loop
 example (Even : Nat → Prop) (zero : Even 0)
     (plusTwo : ∀ n, Even n → Even (n + 2)) : Even 20 := by
   aesop
-
-example : ∃ n : Nat, n ^ 2 = 4 ∧ ∃ n : Nat, n ^ 2 = 9 ∧ True := by
-  aesop
-    (config := { maxRuleApplications := 20, maxGoals := 0, maxRuleApplicationDepth := 0, terminal := false })
-    (config := { maxRuleApplications := 20, maxGoals := 0, maxRuleApplicationDepth := 0, terminal := false })
-  (exists 2)
-  (exists 3)

--- a/AesopTest/Indent.lean
+++ b/AesopTest/Indent.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2025 Alex Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Best, Jannis Limperg
+-/
+
+import Aesop
+
+/-! Test case for clause indentation. We require Aesop tactic clauses to be on
+the same line or indented, to prevent Aesop from mistaking the following
+tactics for clauses. -/
+
+example : ∃ n : Nat, n ^ 2 = 4 ∧ ∃ n : Nat, n ^ 2 = 9 ∧ True := by
+  aesop
+    (config := { maxRuleApplications := 1, warnOnNonterminal := false })
+  (exists 2)
+  (exists 3)
+
+example : ∃ n : Nat, n ^ 2 = 4 ∧ ∃ n : Nat, n ^ 2 = 9 ∧ True := by
+  aesop (config := { maxRuleApplications := 1, warnOnNonterminal := false })
+  (exists 2)
+  (exists 3)


### PR DESCRIPTION
previously things like
```
example : ∃ n : Nat, n ^ 2 = 4 ∧ True := by
  aesop
  (exists 2)
```
would fail as `(exists 2)`  would get parsed as arguments to aesop