### PR TITLE
chore: record dependencies on `declare_aesop_rule_sets`

### DIFF
--- a/Aesop/Frontend/Command.lean
+++ b/Aesop/Frontend/Command.lean
@@ -28,6 +28,8 @@ elab_rules : command
     let dflt := (← dflt?.mapM (elabBoolLit ·)).getD false
     rsNames.forM checkRuleSetNotDeclared
     elabCommand $ ← `(meta initialize ($(quote rsNames).forM $ declareRuleSetUnchecked (isDefault := $(quote dflt))))
+    -- TODO: record dependency on rule set at use site
+    recordExtraRevUseOfCurrentModule
 
 elab (name := addRules)
     attrKind:attrKind "add_aesop_rules " e:Aesop.rule_expr : command => do


### PR DESCRIPTION
This is the coarsest solution to making sure `shake` does not discard imports that are needed solely for their declaration of rule sets: such modules are marked as to be preserved as an import of *any* module that (transitively) used to import them. A more fine-grained approach would likely involve storing the declaring module's name in the rule set and then `recordExtraModUse`ing when the rule set is used (if that is something that in itself can be granularly tracked currently?).