### PR TITLE
chore: capitalize error messages to match `Lean.Meta.throwTacticEx`

### DIFF
--- a/Aesop/Search/Main.lean
+++ b/Aesop/Search/Main.lean
@@ -193,8 +193,8 @@ def throwAesopEx (mvarId : MVarId) (remainingSafeGoals : Array MVarId)
     SearchM Q α := do
   if aesop.smallErrorMessages.get (← getOptions) then
     match msg? with
-    | none => throwError "tactic 'aesop' failed"
-    | some msg => throwError "tactic 'aesop' failed, {msg}"
+    | none => throwError "Tactic `aesop` failed"
+    | some msg => throwError "Tactic `aesop` failed, {msg}"
   else
     let maxRapps := (← read).options.maxSafePrefixRuleApplications
     let suffix :=
@@ -210,8 +210,8 @@ def throwAesopEx (mvarId : MVarId) (remainingSafeGoals : Array MVarId)
         m!"\nRemaining goals after safe rules:{indentD gs}{suffix'}"
     -- Copy-pasta from `Lean.Meta.throwTacticEx`
     match msg? with
-    | none => throwError "tactic 'aesop' failed\nInitial goal:{indentD mvarId}{suffix}"
-    | some msg => throwError "tactic 'aesop' failed, {msg}\nInitial goal:{indentD mvarId}{suffix}"
+    | none => throwError "Tactic `aesop` failed\nInitial goal:{indentD mvarId}{suffix}"
+    | some msg => throwError "Tactic `aesop` failed, {msg}\nInitial goal:{indentD mvarId}{suffix}"
 
 
 -- When we hit a non-fatal error (i.e. the search terminates without a proof

--- a/AesopTest/125.lean
+++ b/AesopTest/125.lean
@@ -8,7 +8,7 @@ def myTacGen : Aesop.TacGen := fun _ => do
   return #[("exact ⟨val - f { val := val, property := property }, fun a ha => by simpa⟩",
             0.9)]
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 theorem foo (f : { x // 0 < x } → { x // 0 < x }) (val : Nat)
     (property : 0 < val) :

--- a/AesopTest/13.lean
+++ b/AesopTest/13.lean
@@ -20,7 +20,7 @@ theorem Perm.any {xs ys : List α} (perm : Perm xs ys) (P : α → Prop)
   induction perm <;> aesop (add safe [constructors Any, cases Any])
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (100) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (100) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 theorem error (P : Nat → Prop) (Δ : List Nat) : Any P Δ := by
@@ -28,7 +28,7 @@ theorem error (P : Nat → Prop) (Δ : List Nat) : Any P Δ := by
     (config := { maxRuleApplications := 100, terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 theorem fine (P : α → Prop) (Δ : List α) : Any P Δ := by

--- a/AesopTest/13_2.lean
+++ b/AesopTest/13_2.lean
@@ -16,7 +16,7 @@ inductive Proof : (Γ Δ : List Φ) → Prop where
   | per_l (Γ Γ' Δ) : Proof Γ Δ → Perm Γ' Γ → Proof Γ' Δ
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (50) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (50) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 theorem weaken (Γ Δ : List Φ) (prf : Proof Γ Δ) (δ : Φ) : Proof Γ (δ :: Δ) := by

--- a/AesopTest/18.lean
+++ b/AesopTest/18.lean
@@ -12,7 +12,7 @@ attribute [aesop safe cases (cases_patterns := [List.Mem _ []])] List.Mem
 attribute [aesop unsafe 50% cases (cases_patterns := [List.Mem _ (_ :: _)])] List.Mem
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 theorem Mem.split [DecidableEq α] (xs : List α) (v : α) (h : v ∈ xs)

--- a/AesopTest/AddRulesCommand.lean
+++ b/AesopTest/AddRulesCommand.lean
@@ -13,7 +13,7 @@ set_option aesop.smallErrorMessages true
 
 structure TT₁ where
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 example : TT₁ := by
   aesop
@@ -36,7 +36,7 @@ example : TT₂ := by
 
 end Test
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 example : TT₂ := by
   aesop
@@ -54,7 +54,7 @@ example : TT₃ := by
 
 end Test
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 example : TT₃ := by
   aesop
@@ -66,7 +66,7 @@ def Test.example : TT₃ := by
 
 structure TT₄ where
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 example : TT₄ := by
   aesop
@@ -83,7 +83,7 @@ axiom U : Type
 axiom f : T → U
 axiom t : T
 
-/-- error: tactic 'aesop' failed, made no progress -/
+/-- error: Tactic `aesop` failed, made no progress -/
 #guard_msgs in
 example : U := by
   aesop

--- a/AesopTest/Aesop.lean
+++ b/AesopTest/Aesop.lean
@@ -50,7 +50,7 @@ structure Wrap (α) where
   unwrap : α
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (20) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (20) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 example (h : α → α) (h' : Wrap α) : α := by
@@ -58,7 +58,7 @@ example (h : α → α) (h' : Wrap α) : α := by
     (config := { maxRuleApplications := 20, maxGoals := 0, maxRuleApplicationDepth := 0, terminal := true })
 
 /--
-error: tactic 'aesop' failed, maximum number of goals (20) reached. Set the 'maxGoals' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of goals (20) reached. Set the 'maxGoals' option to increase the limit.
 -/
 #guard_msgs in
 example (h : α → α) (h' : Wrap α) : α := by
@@ -66,7 +66,7 @@ example (h : α → α) (h' : Wrap α) : α := by
     (config := { maxGoals := 20, maxRuleApplications := 0, maxRuleApplicationDepth := 0, terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (20) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
+error: Tactic `aesop` failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (20) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
 -/
 #guard_msgs in
 example (h : α → α) (h' : Wrap α) : α := by

--- a/AesopTest/AllWeaken.lean
+++ b/AesopTest/AllWeaken.lean
@@ -18,7 +18,7 @@ axiom weaken {α} (P Q : α → Prop) (wk : ∀ x, P x → Q x) (xs : List α)
   (h : All P xs) : All Q xs
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (50) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (50) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 example : All (· ∈ []) (@List.nil α) := by

--- a/AesopTest/ApplyHypsTransparency.lean
+++ b/AesopTest/ApplyHypsTransparency.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 def T := Unit → Nat
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : Nat := by
@@ -24,14 +24,14 @@ example (h : T) : Nat := by
 @[irreducible] def U := Empty
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : Unit → Empty) : U := by
   aesop (config := { applyHypsTransparency := .reducible, terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : Unit → Empty) : U := by

--- a/AesopTest/ApplyTransparency.lean
+++ b/AesopTest/ApplyTransparency.lean
@@ -12,14 +12,14 @@ set_option aesop.smallErrorMessages true
 def T := True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by
   aesop (add safe apply True.intro) (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by
@@ -32,14 +32,14 @@ example : T := by
 @[irreducible] def U := T
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : U := by
   aesop (add safe apply True.intro) (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : U := by
@@ -47,7 +47,7 @@ example : U := by
     (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : U := by

--- a/AesopTest/AssumptionTransparency.lean
+++ b/AesopTest/AssumptionTransparency.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 def T := Empty
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : Empty := by
@@ -20,7 +20,7 @@ example (h : T) : Empty := by
     (config := { assumptionTransparency := .reducible, terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : Empty := by
@@ -33,7 +33,7 @@ example (h : T) : Empty := by
 @[irreducible] def U := False
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : U) : False := by

--- a/AesopTest/CasesTransparency.lean
+++ b/AesopTest/CasesTransparency.lean
@@ -17,14 +17,14 @@ def T := False
 variable {α : Type}
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : α := by
   aesop (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : α := by
@@ -32,7 +32,7 @@ example (h : T) : α := by
     (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) : α := by

--- a/AesopTest/CompositeLocalRuleTerm.lean
+++ b/AesopTest/CompositeLocalRuleTerm.lean
@@ -14,7 +14,7 @@ set_option aesop.smallErrorMessages true
 structure A where
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example (h : A → β → γ) (b : β) : γ := by
@@ -29,7 +29,7 @@ example (h : A → β → γ) (b : β) : γ := by
 -- ... and also by the `simp` builder.
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example {P : α → Prop} (h : A → x = y) (p : P x) : P y := by
@@ -39,7 +39,7 @@ example {P : α → Prop} (h : A → x = y) (p : P x) : P y := by
   aesop (add simp (h {}))
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example {P : α → Prop} (h₁ : A → x = y) (h₂ : A → y = z) (p : P x) : P z := by

--- a/AesopTest/Constructors.lean
+++ b/AesopTest/Constructors.lean
@@ -22,7 +22,7 @@ attribute [-aesop] Even
 def T n := Even n
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T 6 := by

--- a/AesopTest/CustomIndexing.lean
+++ b/AesopTest/CustomIndexing.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 variable {α : Type}
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : α) : α := by

--- a/AesopTest/CustomTactic.lean
+++ b/AesopTest/CustomTactic.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 def Foo := True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Foo := by

--- a/AesopTest/DefaultRuleSets.lean
+++ b/AesopTest/DefaultRuleSets.lean
@@ -13,7 +13,7 @@ set_option aesop.smallErrorMessages true
 def T := True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by
@@ -26,7 +26,7 @@ example : T := by
 def U := True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : U := by

--- a/AesopTest/DestructProductsTransparency.lean
+++ b/AesopTest/DestructProductsTransparency.lean
@@ -17,7 +17,7 @@ structure Sig (α : Sort u) (β : α → Sort v) : Sort _ where
 def T α β := α ∧ β
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T α β) : Sig α (λ _ => β) := by
@@ -29,7 +29,7 @@ example (h : T α β) : Sig α (λ _ => β) := by
 def U := T
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : U α β) : Sig α (λ _ => β) := by
@@ -39,7 +39,7 @@ example (h : U α β) : Sig α (λ _ => β) := by
   aesop (config := { destructProductsTransparency := .default })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : U α β ∧ U γ δ) : Sig α (λ _ => γ) := by

--- a/AesopTest/EnableUnfold.lean
+++ b/AesopTest/EnableUnfold.lean
@@ -13,7 +13,7 @@ set_option aesop.smallErrorMessages true
 def T := True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by

--- a/AesopTest/Erase.lean
+++ b/AesopTest/Erase.lean
@@ -22,7 +22,7 @@ example : Even 2 := by
 attribute [-aesop] Even
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Even 2 := by
@@ -43,7 +43,7 @@ example : Even 2 := by
 erase_aesop_rules [ constructors Even ]
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Even 2 := by

--- a/AesopTest/EraseSimp.lean
+++ b/AesopTest/EraseSimp.lean
@@ -18,14 +18,14 @@ example (n : Nat) : n + m = m + n := by
   aesop
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example (n : Nat) : n + m = m + n := by
   aesop (erase Nat.add_comm) (config := { warnOnNonterminal := false })
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example (n : Nat) : n + m = m + n := by

--- a/AesopTest/EraseUnfold.lean
+++ b/AesopTest/EraseUnfold.lean
@@ -15,7 +15,7 @@ set_option aesop.smallErrorMessages true
 def foo : Nat := 37
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : foo = 37 := by
@@ -32,7 +32,7 @@ example : foo = 37 := by aesop (erase Aesop.BuiltinRules.rfl)
 attribute [-aesop] foo
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : foo = 37 := by

--- a/AesopTest/Forward.lean
+++ b/AesopTest/Forward.lean
@@ -463,7 +463,7 @@ example (a : α) (b : β) (r₁ : (a : α) → (b : β) → γ)
 
 -- ... but this fails:
 
-/-- error: tactic 'aesop' failed, failed to prove the goal after exhaustive search. -/
+/-- error: Tactic `aesop` failed, failed to prove the goal after exhaustive search. -/
 #guard_msgs in
 example {α : Prop} (a : α) (b : β) (r₁ : (a : α) → (b : β) → γ)
     (r₂ : (a : α) → δ) : γ ∧ δ := by

--- a/AesopTest/ForwardConstant.lean
+++ b/AesopTest/ForwardConstant.lean
@@ -13,7 +13,7 @@ structure Foo where
   foo ::
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : Foo := by

--- a/AesopTest/ForwardTransparency.lean
+++ b/AesopTest/ForwardTransparency.lean
@@ -16,7 +16,7 @@ def T := Unit → Empty
 variable {α : Type}
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) (u : Unit) : α := by
@@ -25,14 +25,14 @@ example (h : T) (u : Unit) : α := by
 def U := Unit
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) (u : U) : α := by
   aesop (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : T) (u : U) : α := by
@@ -41,7 +41,7 @@ example (h : T) (u : U) : α := by
 abbrev V := Unit
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h : Unit → Empty) (u : V) : α := by

--- a/AesopTest/ForwardUnknownFVar.lean
+++ b/AesopTest/ForwardUnknownFVar.lean
@@ -11,7 +11,7 @@ attribute [-aesop] Aesop.BuiltinRules.applyHyps
 
 variable (a b c d e f : Nat)
 
-/-- error: tactic 'aesop' failed, failed to prove the goal after exhaustive search. -/
+/-- error: Tactic `aesop` failed, failed to prove the goal after exhaustive search. -/
 #guard_msgs in
 set_option aesop.smallErrorMessages true in
 example (h₃ : c ≤ d) (h₄ : d ≤ e) (h₅ : e ≤ f) (h : a = f) : False := by

--- a/AesopTest/IncompleteScript.lean
+++ b/AesopTest/IncompleteScript.lean
@@ -39,7 +39,7 @@ info: Try this:
 
   [apply]   sorry
 ---
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : Even 5 := by

--- a/AesopTest/Intros.lean
+++ b/AesopTest/Intros.lean
@@ -14,14 +14,14 @@ def Injective₁ (f : α → β) := ∀ x y, f x = f y → x = y
 abbrev Injective₂ (f : α → β) := ∀ x y, f x = f y → x = y
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Injective₁ (@id Nat) := by
   aesop (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Injective₁ (@id Nat) := by
@@ -31,7 +31,7 @@ example : Injective₁ (@id Nat) := by
   aesop (config := { introsTransparency? := some .default })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Injective₂ (@id Nat) := by

--- a/AesopTest/IntrosAllTransparency.lean
+++ b/AesopTest/IntrosAllTransparency.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 @[irreducible] def T := False → True
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by

--- a/AesopTest/LegacyForward.lean
+++ b/AesopTest/LegacyForward.lean
@@ -233,7 +233,7 @@ example (a : α) (b : β) (r₁ : (a : α) → (b : β) → γ)
 
 -- ... but this fails:
 
-/-- error: tactic 'aesop' failed, failed to prove the goal after exhaustive search. -/
+/-- error: Tactic `aesop` failed, failed to prove the goal after exhaustive search. -/
 #guard_msgs in
 example {α : Prop} (a : α) (b : β) (r₁ : (a : α) → (b : β) → γ)
     (r₂ : (a : α) → δ) : γ ∧ δ := by

--- a/AesopTest/LocalRuleSet.lean
+++ b/AesopTest/LocalRuleSet.lean
@@ -13,7 +13,7 @@ set_option aesop.smallErrorMessages true
 -- well when the default rule set is disabled.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Unit := by

--- a/AesopTest/LocalTactic.lean
+++ b/AesopTest/LocalTactic.lean
@@ -10,7 +10,7 @@ set_option aesop.check.all true
 set_option aesop.smallErrorMessages true
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example (m n : Nat) : m * n = n * m := by
@@ -23,7 +23,7 @@ example (m n : Nat) : m * n = n * m := by
   aesop (add safe tactic (by rw [Nat.mul_comm m n]))
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example (m n : Nat) : m * n = n * m := by

--- a/AesopTest/NoNormSimp.lean
+++ b/AesopTest/NoNormSimp.lean
@@ -10,7 +10,7 @@ set_option aesop.check.all true
 set_option aesop.smallErrorMessages true
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : 1 = 2 → False := by

--- a/AesopTest/NoProgress.lean
+++ b/AesopTest/NoProgress.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 def T := True
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : T := by
@@ -54,7 +54,7 @@ attribute [aesop 100%] F'_def
 -- goal.
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : F' := by

--- a/AesopTest/Nonterminal.lean
+++ b/AesopTest/Nonterminal.lean
@@ -39,7 +39,7 @@ example : MyFalse := by
   aesop
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : MyFalse := by

--- a/AesopTest/NormSimp.lean
+++ b/AesopTest/NormSimp.lean
@@ -25,7 +25,7 @@ example (h : (α ∧ β) ∨ γ) : α ∨ γ := by
 -- This test checks that the norm simp config is passed around properly.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example {α β : Prop} (ha : α) (h : α → β) : β := by
@@ -39,7 +39,7 @@ example {α β : Prop} (ha : α) (h : α → β) : β := by
 -- Ditto.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : true && false = false := by
@@ -54,7 +54,7 @@ example : true && false = false := by
 -- `simp at *`.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example {α : Prop} (ha : α) : α := by
@@ -81,7 +81,7 @@ attribute [-aesop] TF
 attribute [aesop simp 3] TF
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : T := by

--- a/AesopTest/RulePattern.lean
+++ b/AesopTest/RulePattern.lean
@@ -46,7 +46,7 @@ axiom triangle (a b : Int) : |a + b| ≤ |a| + |b|
 axiom falso' : True → False
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 Initial goal:
   ⊢ False
 -/

--- a/AesopTest/RuleSetNameHygiene1.lean
+++ b/AesopTest/RuleSetNameHygiene1.lean
@@ -15,7 +15,7 @@ macro "aesop_test" : tactic => `(tactic| aesop (rule_sets := [test]))
 structure TT where
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : TT := by

--- a/AesopTest/RuleSets1.lean
+++ b/AesopTest/RuleSets1.lean
@@ -25,7 +25,7 @@ inductive D : Prop where
 | intro
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : A := by
@@ -38,7 +38,7 @@ example : B := by
   aesop (rule_sets := [test_A, test_B])
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : C := by
@@ -54,7 +54,7 @@ attribute [aesop safe (rule_sets := [test_C])] C
 attribute [-aesop] C
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : C := by
@@ -73,7 +73,7 @@ example : D := by
 attribute [-aesop] ad
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : D := by
@@ -97,7 +97,7 @@ example : E := by
 end
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : E := by
@@ -118,7 +118,7 @@ example : E := by
 end EScope
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : E := by

--- a/AesopTest/Safe.lean
+++ b/AesopTest/Safe.lean
@@ -27,7 +27,7 @@ theorem even'_of_even' : Even' n → Even' n :=
 -- and never visited again.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : Even' 2 := by
@@ -35,7 +35,7 @@ example : Even' 2 := by
     (config := { terminal := true })
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (10) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (10) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 example : Even' 2 := by

--- a/AesopTest/SafePrefixExpansionRappLimit.lean
+++ b/AesopTest/SafePrefixExpansionRappLimit.lean
@@ -23,7 +23,7 @@ example : False := by
   aesop
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
+error: Tactic `aesop` failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
 Initial goal:
   ⊢ False
 Remaining goals after safe rules:

--- a/AesopTest/SafePrefixInTerminalError.lean
+++ b/AesopTest/SafePrefixInTerminalError.lean
@@ -1,7 +1,7 @@
 import Aesop
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 Initial goal:
   ⊢ ∀ (a b : Nat), a + b = b + 2 * a
 Remaining goals after safe rules:

--- a/AesopTest/Simprocs.lean
+++ b/AesopTest/Simprocs.lean
@@ -20,7 +20,7 @@ def unfoldConst («from» to : Name) : Simp.Simproc := λ e =>
 @[irreducible] def T₁ := True
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : T₁ := by
@@ -32,7 +32,7 @@ example : T₁ := by
   aesop
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : T₁ := by
@@ -41,7 +41,7 @@ example : T₁ := by
 @[irreducible] def T₂ := True
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : T₂ := by
@@ -50,7 +50,7 @@ example : T₂ := by
 simproc [aesop_builtin] unfoldT₂ (T₂) := unfoldConst ``T₂ ``True
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 -/
 #guard_msgs in
 example : T₂ := by

--- a/AesopTest/Strategy.lean
+++ b/AesopTest/Strategy.lean
@@ -24,7 +24,7 @@ example : I₁ := by
   aesop (config := { strategy := .breadthFirst })
 
 /--
-error: tactic 'aesop' failed, maximum number of rule applications (10) reached. Set the 'maxRuleApplications' option to increase the limit.
+error: Tactic `aesop` failed, maximum number of rule applications (10) reached. Set the 'maxRuleApplications' option to increase the limit.
 -/
 #guard_msgs in
 example : I₁ := by

--- a/AesopTest/Subst.lean
+++ b/AesopTest/Subst.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 -- These test cases test the builtin subst tactic.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h₁ : x = 5) (h₂ : y = 5) : x = y := by
@@ -25,7 +25,7 @@ example (h₁ : x = 5) (h₂ : y = 5) : x = y := by
 variable {α : Type}
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example {x y z : α} (h₁ : x = y) (h₂ : y = z) : x = z := by
@@ -36,7 +36,7 @@ example {x y z : α} (h₁ : x = y) (h₂ : y = z) : x = z := by
   aesop (config := { useSimpAll := false })
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example {x y : α }(P : ∀ x y, x = y → Prop) (h₁ : x = y) (h₂ : P x y h₁) :
@@ -56,7 +56,7 @@ example {x y : α }(P : ∀ x y, x = y → Prop) (h₁ : x = y) (h₂ : P x y h�
 -- Subst also works for bi-implications.
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example (h₁ : P ↔ Q) (h₂ : Q ↔ R) (h₃ : P) : R  := by
@@ -70,7 +70,7 @@ example (h₁ : P ↔ Q) (h₂ : Q ↔ R) (h₃ : P) : R  := by
 -- builtin simp rule which turns these into actual homogeneous equalities).
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example {P : α → Prop} {x y z : α} (h₁ : x ≍ y) (h₂ : y ≍ z) (h₃ : P x) :

--- a/AesopTest/TacticConfig.lean
+++ b/AesopTest/TacticConfig.lean
@@ -39,7 +39,7 @@ attribute [aesop 50%] Even.zero Even.plus_two
 -- We can also erase global rules...
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : EvenOrOdd 2 := by
@@ -53,7 +53,7 @@ example : EvenOrOdd 2 := by
 
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
 example : EvenOrOdd 2 := by

--- a/AesopTest/TerminalError.lean
+++ b/AesopTest/TerminalError.lean
@@ -9,7 +9,7 @@ import Aesop
 set_option aesop.check.all true
 
 /--
-error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+error: Tactic `aesop` failed, failed to prove the goal after exhaustive search.
 Initial goal:
   ⊢ False
 Remaining goals after safe rules:

--- a/AesopTest/TraceProof.lean
+++ b/AesopTest/TraceProof.lean
@@ -12,7 +12,7 @@ set_option aesop.smallErrorMessages true
 set_option trace.aesop.proof true
 
 /--
-error: tactic 'aesop' failed, made no progress
+error: Tactic `aesop` failed, made no progress
 ---
 trace: [aesop.proof] <no proof>
 -/


### PR DESCRIPTION
Also change to use backticks. Both changes match

https://github.com/leanprover/lean4/blob/3b0f2862196c6a8af9eb0025ee650252694013dd/src/Lean/Meta/Tactic/Util.lean#L46-L49

I think this function was changed upstream recently.