### PR TITLE
chore: adaptations for `nightly-2026-04-17`

### DIFF
--- a/AesopTest/List.lean
+++ b/AesopTest/List.lean
@@ -178,7 +178,7 @@ theorem subset_trans {l₁ l₂ l₃ : List α} : l₁ ⊆ l₂ → l₂ ⊆ l�
 
 -- END PRELUDE
 
-instance unique_of_is_empty [IsEmpty α] : Unique (List α) := by
+def unique_of_is_empty [IsEmpty α] : Unique (List α) := by
   aesop (add 1% cases List)
 
 -- instance : is_left_id (list α) has_append.append [] :=

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "81c23850e7c2b5f82ed16e3569def2fe0f52e1c9",
+   "rev": "1f799a9b117078a3ea6ba5d67c6d9a75fd14e9a0",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "nightly-testing",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "1f799a9b117078a3ea6ba5d67c6d9a75fd14e9a0",
+   "rev": "eed45bf50ee8b4867d48c35e06de388010274264",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "nightly-testing",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-04-06
+leanprover/lean4:nightly-2026-04-17


### PR DESCRIPTION
This PR bumps Aesop to `nightly-2026-04-17` and fixes a broken test, due to having `nonClassInstance` linter upstreamed to the core, as an error.