### PR TITLE
refactor: remove transitive meta import of Lean.Parser.Do

### DIFF
--- a/Aesop/BaseM.lean
+++ b/Aesop/BaseM.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Stats.Basic
 public import Aesop.RulePattern.Cache
 

--- a/Aesop/Builder/Apply.lean
+++ b/Aesop/Builder/Apply.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 import Batteries.Lean.Expr
 

--- a/Aesop/Builder/Basic.lean
+++ b/Aesop/Builder/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.ElabM
 public import Aesop.Rule.Name
 public import Aesop.RuleSet.Member

--- a/Aesop/Builder/Constructors.lean
+++ b/Aesop/Builder/Constructors.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 
 public section

--- a/Aesop/Builder/Default.lean
+++ b/Aesop/Builder/Default.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Constructors
 public import Aesop.Builder.NormSimp
 public import Aesop.Builder.Tactic

--- a/Aesop/Builder/Forward.lean
+++ b/Aesop/Builder/Forward.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 
 public section

--- a/Aesop/Builder/NormSimp.lean
+++ b/Aesop/Builder/NormSimp.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 
 public section

--- a/Aesop/Builder/Tactic.lean
+++ b/Aesop/Builder/Tactic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 
 public section

--- a/Aesop/Builder/Unfold.lean
+++ b/Aesop/Builder/Unfold.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Builder.Basic
 public import Aesop.Util.Unfold
 

--- a/Aesop/EMap.lean
+++ b/Aesop/EMap.lean
@@ -6,7 +6,6 @@ Authors: Jannis Limperg
 
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Tracing
 public import Aesop.Util.Basic
 

--- a/Aesop/Forward/Match/Types.lean
+++ b/Aesop/Forward/Match/Types.lean
@@ -1,6 +1,5 @@
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.PremiseIndex
 public import Aesop.Forward.SlotIndex
 public import Aesop.Forward.Substitution

--- a/Aesop/Forward/RuleInfo.lean
+++ b/Aesop/Forward/RuleInfo.lean
@@ -5,7 +5,6 @@ Authors: Xavier Généreux, Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.PremiseIndex
 public import Aesop.Forward.SlotIndex
 public import Aesop.RulePattern

--- a/Aesop/Index/Basic.lean
+++ b/Aesop/Index/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Util.Basic
 public import Aesop.Rule.Name
 public import Aesop.RulePattern

--- a/Aesop/Index/Forward.lean
+++ b/Aesop/Index/Forward.lean
@@ -5,7 +5,6 @@ Authors: Xavier Généreux, Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.Match.Types
 public import Aesop.Rule.Forward
 public import Aesop.Index.Basic

--- a/Aesop/Index/RulePattern.lean
+++ b/Aesop/Index/RulePattern.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Index.Basic
 public import Aesop.Util.OrderedHashSet
 public import Aesop.RuleTac.GoalDiff

--- a/Aesop/Rule.lean
+++ b/Aesop/Rule.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg, Asta Halkjær From
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Rule.Basic
 public import Aesop.Percent
 

--- a/Aesop/Rule/Basic.lean
+++ b/Aesop/Rule/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Index.Basic
 public import Aesop.Rule.Name
 public import Aesop.RuleTac.Basic

--- a/Aesop/Rule/Forward.lean
+++ b/Aesop/Rule/Forward.lean
@@ -5,7 +5,6 @@ Authors: Xavier Généreux, Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.RuleInfo
 public import Aesop.Percent
 public import Aesop.Rule.Name

--- a/Aesop/RulePattern.lean
+++ b/Aesop/RulePattern.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.Substitution
 public import Aesop.BaseM
 public import Aesop.Rule.Name

--- a/Aesop/RuleSet/Member.lean
+++ b/Aesop/RuleSet/Member.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Rule
 public import Aesop.Rule.Forward
 

--- a/Aesop/RuleTac/Basic.lean
+++ b/Aesop/RuleTac/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Forward.Match.Types
 public import Aesop.Index.Basic
 public import Aesop.Percent

--- a/Aesop/RuleTac/Descr.lean
+++ b/Aesop/RuleTac/Descr.lean
@@ -1,6 +1,5 @@
 module
 
-meta import Lean.Parser.Do
 public import Aesop.RuleTac.Basic
 public import Aesop.Forward.Match.Types
 

--- a/Aesop/RuleTac/GoalDiff.lean
+++ b/Aesop/RuleTac/GoalDiff.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.BaseM
 public import Aesop.RuleTac.FVarIdSubst
 public import Aesop.Util.Basic

--- a/Aesop/RuleTac/Tactic.lean
+++ b/Aesop/RuleTac/Tactic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg, Kaiyu Yang
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.RuleTac.Basic
 public import Aesop.Script.Step
 

--- a/Aesop/Script/Check.lean
+++ b/Aesop/Script/Check.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Check
 public import Aesop.Script.UScript
 

--- a/Aesop/Script/Main.lean
+++ b/Aesop/Script/Main.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Script.Check
 public import Aesop.Script.StructureDynamic
 public import Aesop.Script.StructureStatic

--- a/Aesop/Script/ScriptM.lean
+++ b/Aesop/Script/ScriptM.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.BaseM
 public import Aesop.Script.Step
 public import Aesop.Script.Tactic

--- a/Aesop/Script/StructureDynamic.lean
+++ b/Aesop/Script/StructureDynamic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Script.UScript
 public import Aesop.Script.UScriptToSScript
 public import Aesop.Script.Util

--- a/Aesop/Script/StructureStatic.lean
+++ b/Aesop/Script/StructureStatic.lean
@@ -1,6 +1,5 @@
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Script.UScriptToSScript
 public import Aesop.Script.Util
 

--- a/Aesop/Script/UScript.lean
+++ b/Aesop/Script/UScript.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Script.Step
 import Batteries.Lean.Meta.SavedState
 

--- a/Aesop/Script/UScriptToSScript.lean
+++ b/Aesop/Script/UScriptToSScript.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Script.UScript
 public import Aesop.Script.SScript
 public import Aesop.Tracing

--- a/Aesop/Search/Expansion/Basic.lean
+++ b/Aesop/Search/Expansion/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.RuleTac.Basic
 
 public section

--- a/Aesop/Stats/Basic.lean
+++ b/Aesop/Stats/Basic.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Nanos
 public import Aesop.Rule.Name
 public import Aesop.Tracing

--- a/Aesop/Stats/Extension.lean
+++ b/Aesop/Stats/Extension.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Stats.Basic
 
 public section

--- a/Aesop/Stats/File.lean
+++ b/Aesop/Stats/File.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Stats.Basic
 public import Lean.Data.Position
 

--- a/Aesop/Stats/Report.lean
+++ b/Aesop/Stats/Report.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Percent
 public import Aesop.Stats.Extension
 

--- a/Aesop/Tracing.lean
+++ b/Aesop/Tracing.lean
@@ -8,7 +8,6 @@ module
 public import Aesop.Util.Basic
 public import Lean.Elab.Term
 public import Lean.Meta.Tactic.Simp
-meta import Lean.Parser.Do
 
 public section
 
@@ -110,7 +109,7 @@ macro "aesop_trace![" opt:ident "] " msg:(interpolatedStr(term) <|> term) :
   `(doElem| Lean.addTrace (Aesop.TraceOption.traceClass $opt) $msg)
 
 macro "aesop_trace[" opt:ident "] "
-    msg:(interpolatedStr(term) <|> Parser.Term.do <|> term) : doElem => do
+    msg:(interpolatedStr(term) <|> term) : doElem => do
   let msg := msg.raw
   let opt ← mkIdent <$> resolveTraceOption opt
   match msg with

--- a/Aesop/Tree/UnsafeQueue.lean
+++ b/Aesop/Tree/UnsafeQueue.lean
@@ -5,7 +5,6 @@ Authors: Jannis Limperg
 -/
 module
 
-meta import Lean.Parser.Do
 public import Aesop.Constants
 public import Aesop.Rule
 


### PR DESCRIPTION
The `aesop_trace[...]` macro in `Aesop/Tracing.lean` referenced `Parser.Term.do` as a parser alternative, forcing every downstream module (directly or transitively importing `Aesop.Tracing`) to `meta import Lean.Parser.Do`. Since `term` already parses `do` expressions as a leading parser — and the `` `(do $action) => ... `` match still fires — the explicit alternative is unnecessary. Drops it and removes the now-redundant `meta import` from 37 files.

Diagnosed with help from Sebastian Graf.

🤖 Prepared with Claude Code